### PR TITLE
fix shaders & tests project

### DIFF
--- a/osu.Framework.Live2D.Tests/osu.Framework.Live2D.Tests.csproj
+++ b/osu.Framework.Live2D.Tests/osu.Framework.Live2D.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <GenerateProgramFile>false</GenerateProgramFile>
   </PropertyGroup>
   <ItemGroup>
@@ -9,9 +9,7 @@
     <PackageReference Include="NUnit" Version="3.12.0"/>
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0-alpha.1"/>
     <ProjectReference Include="..\osu.Framework.Live2D\osu.Framework.Live2D.csproj"/>
-    <Reference Include="CubismFramework">
-      <HintPath>./bin/$(Configuration)/$(TargetFramework)/CubismFramework.dll</HintPath>
-    </Reference>
+    <ProjectReference Include="..\CubismFrameworkCS\CubismFramework\CubismFramework.csproj" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\**\*"/>

--- a/osu.Framework.Live2D/Resources/Shaders/sh_MaskedFragment.fs
+++ b/osu.Framework.Live2D/Resources/Shaders/sh_MaskedFragment.fs
@@ -1,3 +1,5 @@
+#version 100
+
 #include "sh_Utils.h"
 
 varying vec2 v_texCoord;
@@ -10,7 +12,7 @@ uniform vec4 u_baseColor;
 void main() {
     vec4 col_forMask = toSRGB(texture2D(s_texture0, v_texCoord) * u_baseColor);
     col_forMask.rgb = col_forMask.rgb * col_forMask.a;
-    
+
     vec4 clipMask = (1.0 - texture2D(s_texture1, v_clipPos.xy / v_clipPos.w)) * u_channelFlag;
     float maskVal = clipMask.r + clipMask.g + clipMask.b + clipMask.a;
 

--- a/osu.Framework.Live2D/Resources/Shaders/sh_MaskedPremultipliedAlphaFragment.fs
+++ b/osu.Framework.Live2D/Resources/Shaders/sh_MaskedPremultipliedAlphaFragment.fs
@@ -1,3 +1,5 @@
+#version 100
+
 precision mediump float;
 
 varying vec2 v_texCoord;

--- a/osu.Framework.Live2D/Resources/Shaders/sh_MaskedVertex.vs
+++ b/osu.Framework.Live2D/Resources/Shaders/sh_MaskedVertex.vs
@@ -1,3 +1,5 @@
+#version 100
+
 attribute vec4 a_position;
 attribute vec2 a_texCoord;
 varying vec2 v_texCoord;

--- a/osu.Framework.Live2D/Resources/Shaders/sh_SetupMaskFragment.fs
+++ b/osu.Framework.Live2D/Resources/Shaders/sh_SetupMaskFragment.fs
@@ -1,3 +1,5 @@
+#version 100
+
 precision mediump float;
 
 varying vec2 v_texCoord;

--- a/osu.Framework.Live2D/Resources/Shaders/sh_SetupMaskVertex.vs
+++ b/osu.Framework.Live2D/Resources/Shaders/sh_SetupMaskVertex.vs
@@ -1,3 +1,5 @@
+#version 100
+
 attribute vec4 a_position;
 attribute vec2 a_texCoord;
 varying vec2 v_texCoord;

--- a/osu.Framework.Live2D/Resources/Shaders/sh_UnmaskedFragment.fs
+++ b/osu.Framework.Live2D/Resources/Shaders/sh_UnmaskedFragment.fs
@@ -1,3 +1,5 @@
+#version 100
+
 #include "sh_Utils.h"
 
 precision mediump float;

--- a/osu.Framework.Live2D/Resources/Shaders/sh_UnmaskedPremultipliedAlphaFragment.fs
+++ b/osu.Framework.Live2D/Resources/Shaders/sh_UnmaskedPremultipliedAlphaFragment.fs
@@ -1,3 +1,5 @@
+#version 100
+
 precision mediump float;
 
 varying vec2 v_texCoord;

--- a/osu.Framework.Live2D/Resources/Shaders/sh_UnmaskedVertex.vs
+++ b/osu.Framework.Live2D/Resources/Shaders/sh_UnmaskedVertex.vs
@@ -1,3 +1,5 @@
+#version 100
+
 attribute vec4 a_position;
 attribute vec2 a_texCoord;
 varying vec2 v_texCoord;


### PR DESCRIPTION
this PR adds `#version 100` headers to the shaders and changes  the tests project target to netcoreapp3.1, also fixes the CubismFrameworkCS reference in the tests project