### PR TITLE
Explicitly headers usually done by of

### DIFF
--- a/osu.Framework.Live2D/Resources/Shaders/sh_MaskedFragment.fs
+++ b/osu.Framework.Live2D/Resources/Shaders/sh_MaskedFragment.fs
@@ -1,8 +1,13 @@
+#ifndef GL_ES
+    #define lowp
+    #define mediump
+    #define highp
+#else
+    // GL_ES expects a defined precision for every member. Users may miss this requirement, so a default precision is specified.
+    precision mediump float;
+#endif
+
 #include "sh_Utils.h"
-
-precision mediump float;
-
-
 
 varying vec2 v_texCoord;
 varying vec4 v_clipPos;

--- a/osu.Framework.Live2D/Resources/Shaders/sh_MaskedPremultipliedAlphaFragment.fs
+++ b/osu.Framework.Live2D/Resources/Shaders/sh_MaskedPremultipliedAlphaFragment.fs
@@ -1,4 +1,11 @@
-precision mediump float;
+#ifndef GL_ES
+    #define lowp
+    #define mediump
+    #define highp
+#else
+    // GL_ES expects a defined precision for every member. Users may miss this requirement, so a default precision is specified.
+    precision mediump float;
+#endif
 
 varying vec2 v_texCoord;
 varying vec4 v_clipPos;

--- a/osu.Framework.Live2D/Resources/Shaders/sh_SetupMaskFragment.fs
+++ b/osu.Framework.Live2D/Resources/Shaders/sh_SetupMaskFragment.fs
@@ -1,4 +1,11 @@
-precision mediump float;
+#ifndef GL_ES
+    #define lowp
+    #define mediump
+    #define highp
+#else
+    // GL_ES expects a defined precision for every member. Users may miss this requirement, so a default precision is specified.
+    precision mediump float;
+#endif
 
 varying vec2 v_texCoord;
 varying vec4 v_myPos;

--- a/osu.Framework.Live2D/Resources/Shaders/sh_UnmaskedFragment.fs
+++ b/osu.Framework.Live2D/Resources/Shaders/sh_UnmaskedFragment.fs
@@ -1,3 +1,12 @@
+#ifndef GL_ES
+    #define lowp
+    #define mediump
+    #define highp
+#else
+    // GL_ES expects a defined precision for every member. Users may miss this requirement, so a default precision is specified.
+    precision mediump float;
+#endif
+
 #include "sh_Utils.h"
 
 varying vec2 v_texCoord;

--- a/osu.Framework.Live2D/Resources/Shaders/sh_UnmaskedPremultipliedAlphaFragment.fs
+++ b/osu.Framework.Live2D/Resources/Shaders/sh_UnmaskedPremultipliedAlphaFragment.fs
@@ -1,4 +1,11 @@
-precision mediump float;
+#ifndef GL_ES
+    #define lowp
+    #define mediump
+    #define highp
+#else
+    // GL_ES expects a defined precision for every member. Users may miss this requirement, so a default precision is specified.
+    precision mediump float;
+#endif
 
 varying vec2 v_texCoord;
 uniform sampler2D s_texture0;


### PR DESCRIPTION
These shader preprocessor directives are added on the fly by osu!framework, however, it seems that the shader compiler is skipping this. As a workaround, we're adding the preprocessor directives that the shader compiler is supposed to append to.

Fixes #24 
FIxes holotrack/holotrack#19