### PR TITLE
Make CubismAssetStore inherit ResourceStore

### DIFF
--- a/osu.Framework.Live2D/Graphics/Cubism/CubismAssetStore.cs
+++ b/osu.Framework.Live2D/Graphics/Cubism/CubismAssetStore.cs
@@ -2,98 +2,60 @@
 // See the LICENCE file in the repository root for full licence text.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using CubismFramework;
 using osu.Framework.IO.Stores;
 
 namespace osu.Framework.Graphics.Cubism
 {
-    public class CubismAssetStore : IResourceStore<CubismAsset>
+    public class CubismAssetStore : ResourceStore<byte[]>
     {
-        private IResourceStore<byte[]> store { get; }
-        private readonly Dictionary<string, CubismAsset> cache = new Dictionary<string, CubismAsset>();
-
-        public CubismAssetStore(IResourceStore<byte[]> store)
+        public CubismAssetStore(IResourceStore<byte[]> store = null)
+            : base(store)
         {
-            this.store = store;
         }
 
         /// <summary>
-        /// Loads a model used for <see cref="CubismSprite"/>.
+        /// Loads a <see cref="CubismAsset"/> used for <see cref="CubismSprite"/>.
         /// </summary>
         /// <param name="name">The path to the model json file.</param>
         /// <returns>The loaded CubismAsset</returns>
-        public CubismAsset Get(string name)
+        public new CubismAsset Get(string name)
         {
             if (string.IsNullOrEmpty(name)) return null;
 
-            lock (cache)
+            CubismAsset asset;
+    
+            try
             {
-                if (!cache.TryGetValue(name, out var asset))
+                var baseDir = name.Split('.', 2)[0];
+                var mdlPath = name.Substring(baseDir.Length + 1, (name.Length - baseDir.Length) - 1);
+                asset = new CubismAsset($"{baseDir}/{mdlPath}", (string path) =>
                 {
-                    try
+                    // CubismFileLoader internally uses System.IO.Path
+                    path = path.Replace(Path.DirectorySeparatorChar, '.');
+                    path = path.Replace(Path.AltDirectorySeparatorChar, '.');
+
+                    // osu!framework prepends an underscore to numbers as file names
+                    var matches = new Regex(@"\.(\d+)").Matches(path);
+                    foreach (Match match in matches)
                     {
-                        var baseDir = name.Split('.', 2)[0];
-                        var mdlPath = name.Substring(baseDir.Length + 1, (name.Length - baseDir.Length) - 1);
-                        asset = new CubismAsset($"{baseDir}/{mdlPath}", (string path) =>
-                        {
-                            // CubismFileLoader internally uses System.IO.Path
-                            path = path.Replace(Path.DirectorySeparatorChar, '.');
-                            path = path.Replace(Path.AltDirectorySeparatorChar, '.');
-
-                            // osu!framework prepends an underscore to numbers as file names
-                            var matches = new Regex(@"\.(\d+)").Matches(path);
-                            foreach (Match match in matches)
-                            {
-                                GroupCollection groups = match.Groups;
-                                var start = groups[1].Index;
-                                var end = start + groups[1].Length;
-                                path = path.Substring(0, start) + $"_{groups[1].Value}" + path.Substring(end, path.Length - end);
-                            }
-
-                            return GetStream(path);
-                        });
+                        GroupCollection groups = match.Groups;
+                        var start = groups[1].Index;
+                        var end = start + groups[1].Length;
+                        path = path.Substring(0, start) + $"_{groups[1].Value}" + path.Substring(end, path.Length - end);
                     }
-                    catch (Exception e)
-                    {
-                        throw e;
-                    }
-                }
 
-                return asset;
+                    return GetStream(path);
+                });
             }
-        }
-
-        public Task<CubismAsset> GetAsync(string name) => Task.Run(() => Get(name));
-
-        public IEnumerable<string> GetAvailableResources() => store.GetAvailableResources().Where(s => s.EndsWith(".model3.json"));
-
-        public Stream GetStream(string name) => store.GetStream(name);
-
-        private bool isDisposed;
-
-        ~CubismAssetStore()
-        {
-            Dispose(false);
-            GC.SuppressFinalize(this);
-        }
-
-        public void Dispose()
-        {
-            Dispose(true);
-        }
-
-        protected virtual void Dispose(bool isDisposing)
-        {
-            if (!isDisposed)
+            catch (Exception e)
             {
-                isDisposed = true;
-                store.Dispose();
+                throw e;
             }
+
+            return asset;
         }
     }
 }


### PR DESCRIPTION
Properly inherit `ResourceStore` so we can add more underlying stores to it. Required by https://github.com/holotrack/holotrack/issues/10.